### PR TITLE
 Remove the "We can't find the Internet" alert

### DIFF
--- a/lib/geo_web/components/alert.ex
+++ b/lib/geo_web/components/alert.ex
@@ -185,19 +185,7 @@ defmodule GeoWeb.Components.Alert do
         width="medium"
         phx-mounted={test_dissolve_alert("#flash-#{@variant}-error", :error)}
       />
-      <.flash
-        id="client-error"
-        kind={:error}
-        variant={@variant}
-        title={gettext("We can't find the internet")}
-        phx-disconnected={show_alert(".phx-client-error #client-error")}
-        phx-connected={hide_alert("#client-error")}
-        width="medium"
-        hidden
-      >
-        {gettext("Attempting to reconnect")}
-        <.icon name="hero-arrow-path" class="ms-1 h-3 w-3 animate-spin" />
-      </.flash>
+
 
       <.flash
         id="server-error"


### PR DESCRIPTION
Closes #61 

Remove the unnecessary "We can't find the Internet" alert that appeared on page load.

The alert, tied to `phx-disconnected` and `phx-connected` bindings, fired immediately on page load before the WebSocket connection was established, causing it to show unnecessarily and persist. This addresses GitHub issue %2361 and is a known Phoenix LiveView behavior (issue %232945).